### PR TITLE
opensuse docker image was deprecated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensuse:latest
+FROM opensuse/archive:latest
 
 ENV LANG=en_US.UTF-8
 


### PR DESCRIPTION
the docker image was deprecated and the image name has changed to opensuse/archive link: https://hub.docker.com/r/opensuse/archive