### PR TITLE
Auto-install build and fix license location error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,19 +2,18 @@ FROM opensuse/leap:latest
 
 ENV LANG=en_US.UTF-8
 
-RUN zypper --non-interactive install --replacefiles which hostname expect net-tools iputils wget vim iproute2 unrar less tar gzip uuidd tcsh libaio
-#RUN zypper refresh && zypper --non-interactive up
-
-# uuidd is needed by nw abap
-RUN mkdir /run/uuidd && chown uuidd /var/run/uuidd && /usr/sbin/uuidd
-
-# Copy expect script + the extracted SAP NW ABAP files to the container
 COPY install.exp /tmp/sapdownloads/
 COPY sapdownloads /tmp/sapdownloads/
+COPY sapdownloads/SYBASE_ASE_TD.lic /tmp/sapdownloads/server/TAR/x86_64
 
 WORKDIR /tmp/sapdownloads
 
-RUN chmod +x install.sh install.exp
+ENV HOSTNAME vhcalnplci
+
+RUN zypper --non-interactive install --replacefiles which hostname expect net-tools iputils wget vim iproute2 unrar tar uuidd tcsh gzip net-tools libaio && \
+ mkdir /run/uuidd && chown uuidd /var/run/uuidd && /usr/sbin/uuidd && \
+ echo "vhcalnplci" >> /etc/hostname && echo $(grep $(hostname) /etc/hosts | cut -f1) vhcalnplci >> /etc/hosts \
+ chmod +x install.sh && chmod +x install.exp && ./install.exp && cd / && rm -rf /tmp/sapdownloads/ 
 
 # Important ports to be exposed (TCP):
 # HTTP
@@ -25,10 +24,5 @@ EXPOSE 44300
 EXPOSE 3300
 # SAP GUI
 EXPOSE 3200
-# SAP Cloud Connector
+# SAP Cloud Connector (not part of installation, so no need to be exposed)
 # EXPOSE 8443
-
-# Unfortunatelly, we cannot run the automated installation directly here!
-# Solution: run original install.sh or the automated install.exp after the image has been created
-# RUN ./install.exp
-

--- a/install.exp
+++ b/install.exp
@@ -33,13 +33,12 @@ if {$force_conservative} {
 set timeout -1
 set password "Down1oad"
 
-# see doco inside install.sh for options, i.e. -h -s -k -g, but we won't use any of them
-spawn ./install.sh
+# see doco inside install.sh for options, i.e. -h -s -k -g
+# Force hostname vhcalnplci during build 
+spawn ./install.sh -s -h vhcalnplci
 
-expect "Your distribution 'opensuse-leap' was not tested. Do you want to continue?"
-send -- "yes\r"
-#expect "Hit enter to continue!" 
-#send -- "\rq" 
+expect "Hit enter to continue!" 
+send -- "\rq" 
 expect "Do you agree to the above license terms? yes/no:"
 send -- "yes\r"
 expect "Please enter a password:"


### PR DESCRIPTION
I ran this docker container recently and ran into a few issues. 
First the license file is not sent to the correct location.
Having to install the SAP system each time a new container is spawned is also tedious so I have forced the hostname during install which appeared to be the only issue from doing the install during build.

This PR should resolve the two issues.