### PR TITLE
Added start- and stop-scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,15 @@ The Dockerfile is based on:
 
 1. Create/Start a container with one of the following commands:
 
-    - Use this if you want to map the default SAP ports as they come on localhost (preferred)
+    - **Recommended:** Use a local folder for the database so that the data remains even after removing the container. Optionally, add a network so that you can connect e. g. a WebIDE lateron
+
+        ```sh
+        docker network create sap
+
+        docker run -p 8000:8000 --network=sap -v <localFolder>:/sybase/NPL/ -p 44300:44300 -p 3300:3300 -p 3200:3200 -h vhcalnplci --name nwabap752 -it nwabap:7.52 /bin/
+        ```
+
+    - Use this if you want to map the default SAP ports as they come on localhost (preferred) and basically only want to evaluate without leaving a trace
 
         ```sh
         docker run -p 8000:8000 -p 44300:44300 -p 3300:3300 -p 3200:3200 -h vhcalnplci --name nwabap752 -it nwabap:7.52 /bin/bash

--- a/startsap.sh
+++ b/startsap.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 DOCKER_PROCESS=$( docker ps | grep nwabap  | sed 's/ .*//' )
 
+if [ !DOCKER_PROCESS ]; then
+    DOCKER_PROCESS=$(docker container ls --all  | grep nwabap  | sed 's/ .*//' )
+    docker restart $DOCKER_PROCESS
+fi
+
 docker exec $DOCKER_PROCESS "/usr/sbin/uuidd"
 docker exec --user npladm $DOCKER_PROCESS /bin/bash -lc "/usr/sap/NPL/SYS/exe/uc/linuxx86_64/startsap ALL"

--- a/startsap.sh
+++ b/startsap.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+DOCKER_PROCESS=$( docker ps | grep nwabap  | sed 's/ .*//' )
+
+docker exec $DOCKER_PROCESS "/usr/sbin/uuidd"
+docker exec --user npladm $DOCKER_PROCESS /bin/bash -lc "/usr/sap/NPL/SYS/exe/uc/linuxx86_64/startsap ALL"

--- a/stopsap.sh
+++ b/stopsap.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+DOCKER_PROCESS=$( docker ps | grep nwabap  | sed 's/ .*//' )
+
+docker exec --user npladm $DOCKER_PROCESS /bin/bash -lc "/usr/sap/NPL/SYS/exe/uc/linuxx86_64/stopsap ALL"


### PR DESCRIPTION
...to simplify starting and stopping the SAP system inside the container.

I was tired of always opening the readme and doing copy-paste when starting and stopping the SAP system.
Thus, I added small bash-scripts which can be executed on the host system to do that.

@nzamani can you make use of that as well? 