### PR TITLE
Adding new set of sysctl shell commands for Windows + Docker Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ The Dockerfile is based on:
 
     - Windows Docker Desktop:
 
-        '''sh
         open powershell
+        ```sh
         wsl -d docker-desktop
         sysctl -w vm.max_map_count=1000000
-        '''
+        ```
 
     Finally, check via `sysctl vm.max_map_count` and exit via `crtl+a` and `ctrl+d`.
 

--- a/README.md
+++ b/README.md
@@ -46,12 +46,20 @@ The Dockerfile is based on:
         sysctl -w vm.max_map_count=1000000
         ```
 
-    - Windows and macOS with Docker Toolbox
+    - Windows and macOS with Docker Toolbox:
 
         ```sh
         docker-machine ssh
         sudo sysctl -w vm.max_map_count=1000000
         ```
+
+    - Windows Docker Desktop:
+
+        '''sh
+        open powershell
+        wsl -d docker-desktop
+        sysctl -w vm.max_map_count=1000000
+        '''
 
     Finally, check via `sysctl vm.max_map_count` and exit via `crtl+a` and `ctrl+d`.
 


### PR DESCRIPTION
I added another set of sysctl shell commands to adjust the vm.max_map_count if someone, like me, is using docker desktop on windows.